### PR TITLE
[Feat] : 커뮤니티 API 틀 구축 및 로그인 API 데이터 모델 생성하여 리팩토링

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-    "java.compile.nullAnalysis.mode": "automatic"
+    "java.compile.nullAnalysis.mode": "automatic",
+    "cSpell.words": [
+        "Farmus"
+    ]
 }

--- a/lib/data/network/community_api_service.dart
+++ b/lib/data/network/community_api_service.dart
@@ -1,17 +1,30 @@
 import 'package:dio/dio.dart';
 import 'package:mojacknong_android/data/network/base_api_services.dart';
+import 'package:mojacknong_android/model/community_posting.dart';
 
 class CommunityApiService {
   // 전체 게시글 조회
-  Future<String> getWholePosting() async {
+  Future<List<CommunityPosting>> getWholePosting() async {
     try {
       Response response =
           await ApiClient().dio.get("/api/community/posting/whole-posting");
-      print(response.data);
-      return "";
+
+      if (response.statusCode == 200) {
+        List<dynamic> data = response.data['data']['wholePostingDTOList'];
+        List<CommunityPosting> posting =
+            data.map((json) => CommunityPosting.fromJson(json)).toList();
+
+        print(data);
+        print(posting);
+
+        return posting;
+      } else {
+        print("서버 에러 ${response.statusCode}");
+        return [];
+      }
     } on DioException catch (e) {
       print(e.message);
-      return "false";
+      return [];
     }
   }
 

--- a/lib/data/network/community_api_service.dart
+++ b/lib/data/network/community_api_service.dart
@@ -2,6 +2,7 @@ import 'package:dio/dio.dart';
 import 'package:mojacknong_android/data/network/base_api_services.dart';
 
 class CommunityApiService {
+  // 전체 게시글 조회
   Future<String> getWholePosting() async {
     try {
       Response response =
@@ -10,7 +11,19 @@ class CommunityApiService {
       return "";
     } on DioException catch (e) {
       print(e.message);
-      print("온보딩실패");
+      return "false";
+    }
+  }
+
+  // 나의 게시글 조회
+  Future<String> getMyPosting() async {
+    try {
+      Response response =
+          await ApiClient().dio.get("/api/community/posting/my-posting");
+      print(response.data);
+      return "";
+    } on DioException catch (e) {
+      print(e.message);
       return "false";
     }
   }

--- a/lib/data/network/community_api_service.dart
+++ b/lib/data/network/community_api_service.dart
@@ -1,0 +1,17 @@
+import 'package:dio/dio.dart';
+import 'package:mojacknong_android/data/network/base_api_services.dart';
+
+class CommunityApiService {
+  Future<String> getWholePosting() async {
+    try {
+      Response response =
+          await ApiClient().dio.get("/api/community/posting/whole-posting");
+      print(response.data);
+      return "";
+    } on DioException catch (e) {
+      print(e.message);
+      print("온보딩실패");
+      return "false";
+    }
+  }
+}

--- a/lib/data/network/login_api_service.dart
+++ b/lib/data/network/login_api_service.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:google_sign_in/google_sign_in.dart';
+import 'package:mojacknong_android/model/farmus_user.dart';
 import 'package:mojacknong_android/res/app_url/app_url.dart';
 
 final GoogleSignIn googleSignIn = GoogleSignIn();
@@ -19,31 +20,26 @@ Dio authDio = Dio(
 );
 
 class LoginApiServices {
-  Future<String> fetchKaKaoData(token) async {
+  Future<FarmusUser> fetchKaKaoData(token) async {
     try {
       Response response = await dio.post(
         '/api/user/auth/kakao-login',
         options: Options(headers: {'Authorization': 'Bearer $token'}),
       );
-      print(response.data);
-      await storage.write(
-          key: 'refreshToken', value: response.data["data"]["refreshToken"]);
-      await storage.write(
-          key: 'accessToken', value: response.data["data"]["accessToken"]);
 
-      print(await storage.read(key: "accessToken"));
+      FarmusUser user = FarmusUser.fromJson(response.data["data"]);
+      await storage.write(key: "refreshToken", value: user.refreshToken);
+      await storage.write(key: 'accessToken', value: user.accessToken);
 
-      if (response.data["data"]['early'] == false) {
-        return "earlyFalse";
-      } else if (response.data["data"]['early'] == true) {
-        return "earlyTrue";
-      } else {
-        return "false";
-      }
-    } on DioError catch (e) {
+      return user;
+    } on DioException catch (e) {
       print(e.message);
       print("실패");
-      return "false";
+      return FarmusUser(
+        nickName: "",
+        refreshToken: "",
+        accessToken: "",
+      );
     }
   }
 

--- a/lib/data/network/login_api_service.dart
+++ b/lib/data/network/login_api_service.dart
@@ -43,51 +43,35 @@ class LoginApiServices {
     }
   }
 
-  Future<String> getGoogleLogin() async {
-    print("구글 로그인 버튼 클릭");
-
-    final GoogleSignInAccount? googleSignInAccount =
-        await googleSignIn.signIn();
-
-    final GoogleSignInAuthentication googleSignInAuthentication =
-        await googleSignInAccount!.authentication;
-
-    print("구글 액세스 토큰 ${googleSignInAuthentication.accessToken}");
-    return fetchGoogleData(googleSignInAuthentication.accessToken);
-  }
-
-  Future<String> fetchGoogleData(token) async {
+  Future<FarmusUser> getGoogleLogin(token) async {
     try {
-      print(token.toString());
       Response response = await dio.post(
         '/api/user/auth/google-login',
         options: Options(headers: {'Authorization': 'Bearer $token'}),
       );
       print(response.data);
-      await storage.write(
-          key: 'refreshToken', value: response.data["data"]["refreshToken"]);
-      await storage.write(
-          key: 'accessToken', value: response.data["data"]["accessToken"]);
+
+      FarmusUser user = FarmusUser.fromJson(response.data["data"]);
+      await storage.write(key: 'refreshToken', value: user.refreshToken);
+      await storage.write(key: 'accessToken', value: user.accessToken);
 
       final accessGoogleToken = await storage.read(key: 'accessToken');
       final refreshGoogleToken = await storage.read(key: 'refreshToken');
       print("성공 \n액세스 : $accessGoogleToken \n리프레시 : $refreshGoogleToken");
 
-      if (response.data["data"]['early'] == false) {
-        return "earlyFalse";
-      } else if (response.data["data"]['early'] == true) {
-        return "earlyTrue";
-      } else {
-        return "false";
-      }
-    } on DioError catch (e) {
+      return user;
+    } on DioException catch (e) {
       print(e.message);
       print("실패");
-      return "false";
+      return FarmusUser(
+        nickName: "",
+        refreshToken: "",
+        accessToken: "",
+      );
     }
   }
 
-  Future<String> reissue() async {
+  Future<FarmusUser> reissue() async {
     try {
       final token = await storage.read(key: 'refreshToken');
       print("토큰 $token");
@@ -101,19 +85,26 @@ class LoginApiServices {
       print(response.data);
       print("reissue 성공");
 
-      await storage.write(
-          key: "accessToken", value: response.data["accessToken"]);
+      FarmusUser user = FarmusUser.fromJson(response.data["data"]);
+      await storage.write(key: "accessToken", value: user.accessToken);
       final newAccessToken = await storage.read(key: 'accessToken');
       print("새 액세스 토큰 : $newAccessToken");
+
+      return user;
     } on DioError catch (e) {
       print(e.message);
       print(e.response);
       print("reissue 실패");
+
+      return FarmusUser(
+        nickName: "",
+        refreshToken: "",
+        accessToken: "",
+      );
     }
-    return "";
   }
 
-  Future<String> logout() async {
+  Future<FarmusUser> logout() async {
     try {
       final accessToken = await storage.read(key: 'accessToken');
 
@@ -127,21 +118,38 @@ class LoginApiServices {
           await storage.delete(key: "accessToken");
           await storage.delete(key: "refreshToken");
           print("로그아웃 성공");
-          return "success";
+
+          return FarmusUser(
+            nickName: "",
+            refreshToken: "",
+            accessToken: "",
+          );
         } else {
           print("로그아웃 실패 ${response.statusCode}");
-          return "failure";
+          return FarmusUser(
+            nickName: "",
+            refreshToken: "",
+            accessToken: "",
+          );
         }
       } else {
         print("로그아웃 실패 : 액세스 토큰 없음");
-        return "failure";
+        return FarmusUser(
+          nickName: "",
+          refreshToken: "",
+          accessToken: "",
+        );
       }
     } on DioError catch (e) {
       print("로그아웃 실패 : ${e.message}");
       if (e.response != null) {
         print("응답 : ${e.response}");
       }
-      return "failure";
+      return FarmusUser(
+        nickName: "",
+        refreshToken: "",
+        accessToken: "",
+      );
     }
   }
 }

--- a/lib/data/network/onboarding_api_service.dart
+++ b/lib/data/network/onboarding_api_service.dart
@@ -23,7 +23,7 @@ class OnboardingApiService {
 
   Future<String> postUserData(File? imageFile, String nickname) async {
     try {
-      print(imageFile);
+      print("이미지이미지 $imageFile");
       FormData formData;
 
       if (imageFile != null) {

--- a/lib/data/network/onboarding_api_service.dart
+++ b/lib/data/network/onboarding_api_service.dart
@@ -21,12 +21,42 @@ class OnboardingApiService {
     }
   }
 
+  Future<String> postProfileImage(File imageFile) async {
+    try {
+      Response response = await ApiClient()
+          .dio
+          .post('/api/user/profileImage', data: imageFile.path);
+
+      print(response.data);
+      return "성공";
+    } on DioException catch (e) {
+      print(e.message);
+      return "실패";
+    }
+  }
+
+  Future<String> postNickName(String nickName) async {
+    try {
+      print(nickName);
+      Response response =
+          await ApiClient().dio.post('/api/user/nickname', data: nickName);
+
+      print(response.data);
+      return "성공";
+    } on DioException catch (e) {
+      print(e.message);
+      return "실패";
+    }
+  }
+
   Future<String> postUserData(File? imageFile, String nickname) async {
     try {
       print("이미지이미지 $imageFile");
       FormData formData;
 
       if (imageFile != null) {
+        print("이미지이미지 ${imageFile.path}");
+
         formData = FormData.fromMap({
           'file': await MultipartFile.fromFile(imageFile.path,
               filename: imageFile.path.split('/').last),
@@ -34,6 +64,7 @@ class OnboardingApiService {
         });
       } else {
         formData = FormData.fromMap({
+          'file': "",
           'nickName': nickname,
         });
       }

--- a/lib/model/community_data_model.dart
+++ b/lib/model/community_data_model.dart
@@ -1,0 +1,42 @@
+class CommunityDataModel {}
+
+class CommunityPosting {
+  final int userId;
+  final String title;
+  final String contents;
+  final List<String> postingImage;
+  final int postingId;
+  final List<String> tagName;
+  final String createdAt;
+  final int commentCount;
+  final String nickName;
+  final String userImageUrl;
+
+  CommunityPosting({
+    required this.userId,
+    required this.title,
+    required this.contents,
+    required this.postingImage,
+    required this.postingId,
+    required this.tagName,
+    required this.createdAt,
+    required this.commentCount,
+    required this.nickName,
+    required this.userImageUrl,
+  });
+
+  factory CommunityPosting.fromJson(Map<String, dynamic> json) {
+    return CommunityPosting(
+      userId: json['userId'],
+      title: json['title'],
+      contents: json['contents'],
+      postingImage: List<String>.from(json['postingImage']),
+      postingId: json['postingId'],
+      tagName: List<String>.from(json['tagName']),
+      createdAt: json['created_at'],
+      commentCount: json['commentCount'],
+      nickName: json['nickName'],
+      userImageUrl: json['userImageUrl'],
+    );
+  }
+}

--- a/lib/model/community_posting.dart
+++ b/lib/model/community_posting.dart
@@ -1,5 +1,3 @@
-class CommunityDataModel {}
-
 class CommunityPosting {
   final int userId;
   final String title;

--- a/lib/model/community_posting.dart
+++ b/lib/model/community_posting.dart
@@ -4,7 +4,7 @@ class CommunityPosting {
   final String contents;
   final List<String> postingImage;
   final int postingId;
-  final List<String> tagName;
+  final String tag;
   final String createdAt;
   final int commentCount;
   final String nickName;
@@ -16,7 +16,7 @@ class CommunityPosting {
     required this.contents,
     required this.postingImage,
     required this.postingId,
-    required this.tagName,
+    required this.tag,
     required this.createdAt,
     required this.commentCount,
     required this.nickName,
@@ -24,17 +24,19 @@ class CommunityPosting {
   });
 
   factory CommunityPosting.fromJson(Map<String, dynamic> json) {
+    List<String> images = List<String>.from(json['postingImage'] ?? []);
+
     return CommunityPosting(
-      userId: json['userId'],
-      title: json['title'],
-      contents: json['contents'],
-      postingImage: List<String>.from(json['postingImage']),
-      postingId: json['postingId'],
-      tagName: List<String>.from(json['tagName']),
-      createdAt: json['created_at'],
-      commentCount: json['commentCount'],
-      nickName: json['nickName'],
-      userImageUrl: json['userImageUrl'],
+      userId: json['userId'] ?? 0,
+      title: json['title'] ?? '',
+      contents: json['contents'] ?? '',
+      postingImage: images,
+      postingId: json['postingId'] ?? 0,
+      tag: json['tag'] ?? '',
+      createdAt: json['created_at'] ?? '',
+      commentCount: json['commentCount'] ?? 0,
+      nickName: json['nickName'] ?? '',
+      userImageUrl: json['userImageUrl'] ?? '',
     );
   }
 }

--- a/lib/model/data_model.dart
+++ b/lib/model/data_model.dart
@@ -1,1 +1,0 @@
-class DataModel {}

--- a/lib/model/farmus_user.dart
+++ b/lib/model/farmus_user.dart
@@ -1,0 +1,22 @@
+class FarmusUser {
+  String? nickName;
+  String refreshToken;
+  String accessToken;
+  bool? early;
+
+  FarmusUser({
+    this.nickName,
+    required this.refreshToken,
+    required this.accessToken,
+    this.early,
+  });
+
+  factory FarmusUser.fromJson(Map<String, dynamic> json) {
+    return FarmusUser(
+      nickName: json['nickName'],
+      refreshToken: json["refreshToken"],
+      accessToken: json["accessToken"],
+      early: json['early'],
+    );
+  }
+}

--- a/lib/model/farmus_user.dart
+++ b/lib/model/farmus_user.dart
@@ -1,22 +1,30 @@
 class FarmusUser {
-  String? nickName;
   String refreshToken;
   String accessToken;
+  String? nickName;
   bool? early;
+  String? motivation;
+  int? time;
+  String? skill;
 
   FarmusUser({
-    this.nickName,
     required this.refreshToken,
     required this.accessToken,
+    this.nickName,
     this.early,
+    this.motivation,
+    this.time,
+    this.skill,
   });
 
   factory FarmusUser.fromJson(Map<String, dynamic> json) {
     return FarmusUser(
-      nickName: json['nickName'],
-      refreshToken: json["refreshToken"],
-      accessToken: json["accessToken"],
-      early: json['early'],
-    );
+        refreshToken: json["refreshToken"],
+        accessToken: json["accessToken"],
+        nickName: json['nickName'],
+        early: json['early'],
+        motivation: json['motivation'],
+        time: json['time'],
+        skill: json["skill"]);
   }
 }

--- a/lib/repository/community_repository.dart
+++ b/lib/repository/community_repository.dart
@@ -1,8 +1,10 @@
 import 'package:mojacknong_android/data/network/community_api_service.dart';
+import 'package:mojacknong_android/model/community_posting.dart';
 
 class CommunityRepository {
-  static Future<String> getWholePosting() async {
-    String response = await CommunityApiService().getWholePosting();
+  static Future<List<CommunityPosting>> getWholePosting() async {
+    List<CommunityPosting> response =
+        await CommunityApiService().getWholePosting();
     return response;
   }
 }

--- a/lib/repository/community_repository.dart
+++ b/lib/repository/community_repository.dart
@@ -1,0 +1,8 @@
+import 'package:mojacknong_android/data/network/community_api_service.dart';
+
+class CommunityRepository {
+  static Future<String> getWholePosting() async {
+    String response = await CommunityApiService().getWholePosting();
+    return response;
+  }
+}

--- a/lib/repository/login_repository.dart
+++ b/lib/repository/login_repository.dart
@@ -8,8 +8,8 @@ class LoginRepository {
     return user;
   }
 
-  static Future<dynamic> googleLoginApi() async {
-    String response = await LoginApiServices().getGoogleLogin();
+  static Future<FarmusUser> googleLoginApi(token) async {
+    FarmusUser response = await LoginApiServices().getGoogleLogin(token);
     return response;
   }
 

--- a/lib/repository/login_repository.dart
+++ b/lib/repository/login_repository.dart
@@ -1,10 +1,11 @@
 import 'package:mojacknong_android/data/network/login_api_service.dart';
+import 'package:mojacknong_android/model/farmus_user.dart';
 
 class LoginRepository {
-  static Future<dynamic> kakaoLoginApi(token) async {
-    String? response = await LoginApiServices().fetchKaKaoData(token);
-    print(response);
-    return response;
+  static Future<FarmusUser> kakaoLoginApi(token) async {
+    FarmusUser user = await LoginApiServices().fetchKaKaoData(token);
+    print("데이터데이터 $user");
+    return user;
   }
 
   static Future<dynamic> googleLoginApi() async {

--- a/lib/repository/onboarding_repository.dart
+++ b/lib/repository/onboarding_repository.dart
@@ -6,6 +6,7 @@ class OnboardingRepository {
   static Future<String> getProfileImageApi() async {
     String response = await OnboardingApiService().getProfileImage();
     print("프로필이미지 $response");
+
     return response;
   }
 
@@ -14,8 +15,10 @@ class OnboardingRepository {
     print("프로필 $imageFile");
     if (imageFile != null) {
       response = await OnboardingApiService().postUserData(imageFile, nickname);
+      print("프로필 이미지 보내기 $response");
     } else {
-      response = await OnboardingApiService().postUserData(imageFile, nickname);
+      response = await OnboardingApiService().postUserData(null, nickname);
+      print("프로필 이미지 보내기^^^^ $response");
     }
     print("프로필 이미지 보내기 $response");
     return response;

--- a/lib/repository/onboarding_repository.dart
+++ b/lib/repository/onboarding_repository.dart
@@ -17,10 +17,9 @@ class OnboardingRepository {
       response = await OnboardingApiService().postUserData(imageFile, nickname);
       print("프로필 이미지 보내기 $response");
     } else {
-      response = await OnboardingApiService().postUserData(null, nickname);
+      response = await OnboardingApiService().postNickName(nickname);
       print("프로필 이미지 보내기^^^^ $response");
     }
-    print("프로필 이미지 보내기 $response");
     return response;
   }
 

--- a/lib/view/community/community_screen.dart
+++ b/lib/view/community/community_screen.dart
@@ -59,6 +59,9 @@ class _CommunityScreenState extends State<CommunityScreen> {
           ),
           Row(
             children: [
+              SizedBox(
+                width: 10,
+              ),
               ...category.map(
                 (item) {
                   return CommunityCategory(
@@ -70,6 +73,9 @@ class _CommunityScreenState extends State<CommunityScreen> {
                   alignment: Alignment.centerRight,
                   child: ButtonNextMyPost(),
                 ),
+              ),
+              SizedBox(
+                width: 10,
               ),
             ],
           ),

--- a/lib/view/community/community_screen.dart
+++ b/lib/view/community/community_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:mojacknong_android/common/custom_app_bar.dart';
+import 'package:mojacknong_android/repository/community_repository.dart';
 import 'package:mojacknong_android/view/community/component/button_next_my_post.dart';
 import 'package:mojacknong_android/view/community/component/community_category.dart';
 import 'package:mojacknong_android/view/community/component/community_feed.dart';
@@ -40,6 +41,12 @@ class _CommunityScreenState extends State<CommunityScreen> {
       "image": "assets/image/image_example_community2.png",
     },
   ];
+
+  @override
+  void initState() {
+    super.initState();
+    getWholePosting();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -97,5 +104,9 @@ class _CommunityScreenState extends State<CommunityScreen> {
       ),
       floatingActionButton: FloatingButtonPost(),
     );
+  }
+
+  Future<String?> getWholePosting() {
+    return CommunityRepository.getWholePosting();
   }
 }

--- a/lib/view/community/community_screen.dart
+++ b/lib/view/community/community_screen.dart
@@ -17,7 +17,7 @@ class _CommunityScreenState extends State<CommunityScreen> {
   final CommunityFeedController feedController =
       Get.put(CommunityFeedController());
 
-  List<String> category = <String>["도와주세요", "자랑할래요", "정보나눔"];
+  List<String> category = <String>["도와주세요", "자랑할래요", "정보나눠요"];
 
   List<Map<String, String>> dummyData = [
     {

--- a/lib/view/community/community_screen.dart
+++ b/lib/view/community/community_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:mojacknong_android/common/custom_app_bar.dart';
+import 'package:mojacknong_android/model/community_posting.dart';
 import 'package:mojacknong_android/repository/community_repository.dart';
 import 'package:mojacknong_android/view/community/component/button_next_my_post.dart';
 import 'package:mojacknong_android/view/community/component/community_category.dart';
@@ -19,28 +20,7 @@ class _CommunityScreenState extends State<CommunityScreen> {
 
   List<String> category = <String>["도와주세요", "자랑할래요", "정보나눠요"];
 
-  List<Map<String, String>> dummyData = [
-    {
-      "profileImage": "assets/image/image_example_profile.png",
-      "nickname": "노준국",
-      "postTime": "11/6 12:18",
-      "comment": "0",
-      "postCategory": "도와주세요",
-      "title": "방울토마토가 자라지 않습니다..",
-      "content": "왜 안자라는 걸까요? 봐주실 분 구합니다.",
-      "image": "assets/image/image_example_community.png",
-    },
-    {
-      "profileImage": "assets/image/image_example_profile2.png",
-      "nickname": "감자",
-      "postTime": "11/6 12:18",
-      "comment": "0",
-      "postCategory": "자랑할래요",
-      "title": "25년 생에 처음으로",
-      "content": "새싹 발아에 성공했습니다. 감격스럽네요.. \n저는 이제 농약손이 아니에요 ^_____^",
-      "image": "assets/image/image_example_community2.png",
-    },
-  ];
+  List<CommunityPosting> communityPostings = [];
 
   @override
   void initState() {
@@ -81,18 +61,22 @@ class _CommunityScreenState extends State<CommunityScreen> {
           ),
           Expanded(
             child: ListView.builder(
-              itemCount: dummyData.length,
+              itemCount: communityPostings.length,
               itemBuilder: (context, index) {
+                CommunityPosting posting = communityPostings[index];
                 feedController.setData(
-                  profileImage: dummyData[index]['profileImage']!,
-                  nickname: dummyData[index]['nickname']!,
-                  postTime: dummyData[index]['postTime']!,
-                  comment: dummyData[index]['comment']!,
-                  postCategory: dummyData[index]['postCategory']!,
-                  title: dummyData[index]['title']!,
-                  content: dummyData[index]['content']!,
-                  image: dummyData[index]['image']!,
+                  profileImage: posting.userImageUrl,
+                  nickname: posting.nickName,
+                  postTime: posting.createdAt,
+                  comment: posting.commentCount.toString(),
+                  postCategory: posting.tag,
+                  title: posting.title,
+                  content: posting.contents,
+                  image: posting.postingImage.isNotEmpty
+                      ? posting.postingImage[0]
+                      : "",
                 );
+
                 return CommunityFeed(
                   profileImage: feedController.profileImage.value,
                   nickname: feedController.nickname.value,
@@ -112,7 +96,11 @@ class _CommunityScreenState extends State<CommunityScreen> {
     );
   }
 
-  Future<String?> getWholePosting() {
-    return CommunityRepository.getWholePosting();
+  Future<void> getWholePosting() async {
+    List<CommunityPosting> postings =
+        await CommunityRepository.getWholePosting();
+    setState(() {
+      communityPostings = postings;
+    });
   }
 }

--- a/lib/view/community/component/button_next_my_post.dart
+++ b/lib/view/community/component/button_next_my_post.dart
@@ -28,7 +28,7 @@ class ButtonNextMyPost extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             const Text(
-              '나의 글',
+              '내 글',
               style: TextStyle(
                 color: FarmusThemeData.primary,
                 fontSize: 14,

--- a/lib/view/community/component/category_list.dart
+++ b/lib/view/community/component/category_list.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:mojacknong_android/common/bouncing.dart';
+import 'package:mojacknong_android/common/farmus_theme_data.dart';
+import 'package:mojacknong_android/view_model/controllers/community_post_controller.dart';
+
+class CategoryList extends StatefulWidget {
+  @override
+  State<CategoryList> createState() => _CategoryListState();
+}
+
+class _CategoryListState extends State<CategoryList> {
+  final CommunityPostController postController =
+      Get.put(CommunityPostController());
+
+  @override
+  void initState() {
+    super.initState();
+
+    // 초기에 모두 false로 설정
+    postController.isSelected1.value = false;
+    postController.isSelected2.value = false;
+    postController.isSelected3.value = false;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        buildCategoryButton("도와주세요", postController.isSelected1),
+        buildCategoryButton("자랑할래요", postController.isSelected2),
+        buildCategoryButton("정보나눠요", postController.isSelected3),
+      ],
+    );
+  }
+
+  Widget buildCategoryButton(String categoryName, RxBool isSelected) {
+    return Bouncing(
+      onPress: () {
+        setState(() {
+          // 해당 카테고리 선택 메서드 호출
+          if (categoryName == "도와주세요") {
+            postController.selectCategory1();
+          } else if (categoryName == "자랑할래요") {
+            postController.selectCategory2();
+          } else if (categoryName == "정보나눠요") {
+            postController.selectCategory3();
+          }
+
+          // 나머지 카테고리의 선택 상태를 false로 설정
+          postController.isSelected1.value = categoryName == "도와주세요";
+          postController.isSelected2.value = categoryName == "자랑할래요";
+          postController.isSelected3.value = categoryName == "정보나눠요";
+
+          print(
+              "${postController.isSelected1}, ${postController.isSelected2}, ${postController.isSelected3}");
+        });
+      },
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        child: Container(
+          decoration: BoxDecoration(
+            color: isSelected.value
+                ? FarmusThemeData.category
+                : FarmusThemeData.background,
+            borderRadius: BorderRadius.circular(30),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+            child: GestureDetector(
+              child: Text(
+                categoryName,
+                style: TextStyle(
+                  color: isSelected.value
+                      ? FarmusThemeData.white
+                      : FarmusThemeData.dark,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/community/component/community_category.dart
+++ b/lib/view/community/component/community_category.dart
@@ -26,9 +26,6 @@ class CommunityCategory extends StatefulWidget {
 
 class _CommunityCategoryState extends State<CommunityCategory> {
   late bool isSelected = false;
-  late bool isSelected1 = false;
-  late bool isSelected2 = false;
-  late bool isSelected3 = false;
 
   @override
   void initState() {
@@ -44,48 +41,22 @@ class _CommunityCategoryState extends State<CommunityCategory> {
           if (isSelected) {
             if (widget.feedController != null) {
               widget.feedController!.selectCategory(""); // 선택 해제
-            } else if (widget.postController != null) {
-              widget.postController!.selectCategory(""); // 선택 해제
             }
           } else {
             if (widget.feedController != null) {
               widget.feedController!.selectCategory(widget.category); // 선택
-            } else if (widget.postController != null) {
-              if (widget.category == "도와주세요") {
-                widget.postController!.selectCategory1();
-                isSelected1 = true;
-                isSelected2 = false;
-                isSelected3 = false;
-                print("$isSelected1, $isSelected2, $isSelected3");
-              } else if (widget.category == "자랑할래요") {
-                widget.postController!.selectCategory2();
-                isSelected1 = false;
-                isSelected2 = true;
-                isSelected3 = false;
-                print("$isSelected1, $isSelected2, $isSelected3");
-              } else if (widget.category == "정보나눠요") {
-                widget.postController!.selectCategory3();
-                isSelected1 = false;
-                isSelected2 = false;
-                isSelected3 = true;
-                print("$isSelected1, $isSelected2, $isSelected3");
-              }
             }
           }
           isSelected = !isSelected;
         });
       },
       child: Padding(
-        padding: const EdgeInsets.all(8),
+        padding: const EdgeInsets.symmetric(horizontal: 4),
         child: Container(
           decoration: BoxDecoration(
             color: isSelected
                 ? FarmusThemeData.category
-                : isSelected1
-                    ? FarmusThemeData.category
-                    : isSelected2 || isSelected3
-                        ? FarmusThemeData.category
-                        : FarmusThemeData.background,
+                : FarmusThemeData.background,
             borderRadius: BorderRadius.circular(30),
           ),
           child: Padding(

--- a/lib/view/community/component/community_category.dart
+++ b/lib/view/community/component/community_category.dart
@@ -25,10 +25,10 @@ class CommunityCategory extends StatefulWidget {
 }
 
 class _CommunityCategoryState extends State<CommunityCategory> {
-  late bool isSelected;
-  late bool isSelected1;
-  late bool isSelected2;
-  late bool isSelected3;
+  late bool isSelected = false;
+  late bool isSelected1 = false;
+  late bool isSelected2 = false;
+  late bool isSelected3 = false;
 
   @override
   void initState() {
@@ -56,17 +56,19 @@ class _CommunityCategoryState extends State<CommunityCategory> {
                 isSelected1 = true;
                 isSelected2 = false;
                 isSelected3 = false;
+                print("$isSelected1, $isSelected2, $isSelected3");
               } else if (widget.category == "자랑할래요") {
                 widget.postController!.selectCategory2();
-                isSelected1 = true;
+                isSelected1 = false;
                 isSelected2 = true;
                 isSelected3 = false;
-              } else if (widget.category == "정보나눔") {
+                print("$isSelected1, $isSelected2, $isSelected3");
+              } else if (widget.category == "정보나눠요") {
                 widget.postController!.selectCategory3();
                 isSelected1 = false;
                 isSelected2 = false;
                 isSelected3 = true;
-                isSelected3 = !isSelected3;
+                print("$isSelected1, $isSelected2, $isSelected3");
               }
             }
           }
@@ -79,7 +81,11 @@ class _CommunityCategoryState extends State<CommunityCategory> {
           decoration: BoxDecoration(
             color: isSelected
                 ? FarmusThemeData.category
-                : FarmusThemeData.background,
+                : isSelected1
+                    ? FarmusThemeData.category
+                    : isSelected2 || isSelected3
+                        ? FarmusThemeData.category
+                        : FarmusThemeData.background,
             borderRadius: BorderRadius.circular(30),
           ),
           child: Padding(

--- a/lib/view/community/component/community_feed.dart
+++ b/lib/view/community/component/community_feed.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:mojacknong_android/common/bouncing.dart';
 import 'package:mojacknong_android/view/community/component/community_comment_count.dart';
 import 'package:mojacknong_android/view/community/component/community_content.dart';
 import 'package:mojacknong_android/view/community/component/community_picture.dart';
@@ -31,8 +30,8 @@ class CommunityFeed extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Bouncing(
-      onPress: () {
+    return GestureDetector(
+      onTap: () {
         Navigator.push(
           context,
           MaterialPageRoute(

--- a/lib/view/community/component/community_picture.dart
+++ b/lib/view/community/component/community_picture.dart
@@ -5,6 +5,7 @@ class CommunityPicture extends StatelessWidget {
   final String image;
 
   CommunityPicture({required this.image});
+
   @override
   Widget build(BuildContext context) {
     return Padding(
@@ -13,18 +14,52 @@ class CommunityPicture extends StatelessWidget {
         width: double.infinity,
         height: 248,
         decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(8),
-            color: FarmusThemeData.background),
-        child: image.isEmpty
-            ? Image.asset(
-                "assets/image/image_example_community.png",
-                fit: BoxFit.fill,
-              )
-            : Image.network(
-                image,
-                fit: BoxFit.fill,
-              ),
+          borderRadius: BorderRadius.circular(8),
+          color: FarmusThemeData.background,
+        ),
+        child: _buildImage(),
       ),
     );
+  }
+
+  Widget _buildImage() {
+    try {
+      return image.isEmpty
+          ? Image.asset(
+              "assets/image/image_example_community.png",
+              fit: BoxFit.fill,
+            )
+          : Image.network(
+              image,
+              fit: BoxFit.fill,
+              loadingBuilder: (BuildContext context, Widget child,
+                  ImageChunkEvent? loadingProgress) {
+                if (loadingProgress == null) {
+                  return child;
+                } else if (loadingProgress.cumulativeBytesLoaded ==
+                    loadingProgress.expectedTotalBytes) {
+                  // 이미지가 완전히 로드된 경우
+                  return child;
+                } else {
+                  // 이미지 로딩 중
+                  return Center(
+                    child: CircularProgressIndicator(
+                      valueColor: const AlwaysStoppedAnimation<Color>(
+                          FarmusThemeData.brownButton),
+                      value: loadingProgress.expectedTotalBytes != null
+                          ? loadingProgress.cumulativeBytesLoaded /
+                              (loadingProgress.expectedTotalBytes ?? 1)
+                          : null,
+                    ),
+                  );
+                }
+              },
+            );
+    } catch (e) {
+      return Image.asset(
+        "assets/image/image_example_community2.png",
+        fit: BoxFit.fill,
+      );
+    }
   }
 }

--- a/lib/view/community/component/community_picture.dart
+++ b/lib/view/community/component/community_picture.dart
@@ -15,10 +15,15 @@ class CommunityPicture extends StatelessWidget {
         decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(8),
             color: FarmusThemeData.background),
-        child: Image.asset(
-          image,
-          fit: BoxFit.fill,
-        ),
+        child: image.isEmpty
+            ? Image.asset(
+                "assets/image/image_example_community.png",
+                fit: BoxFit.fill,
+              )
+            : Image.network(
+                image,
+                fit: BoxFit.fill,
+              ),
       ),
     );
   }

--- a/lib/view/community/component/community_profile.dart
+++ b/lib/view/community/component/community_profile.dart
@@ -28,12 +28,19 @@ class _CommunityProfileState extends State<CommunityProfile> {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          Image.asset(
-            widget.profileImage,
-            width: 32,
-            height: 32,
-            fit: BoxFit.fill,
-          ),
+          widget.profileImage.isEmpty
+              ? Image.asset(
+                  "assets/image/image_example_profile2.png",
+                  width: 32,
+                  height: 32,
+                  fit: BoxFit.fill,
+                )
+              : Image.network(
+                  widget.profileImage,
+                  width: 32,
+                  height: 32,
+                  fit: BoxFit.fill,
+                ),
           const SizedBox(
             width: 8,
           ),

--- a/lib/view/community/component/my_post_feed.dart
+++ b/lib/view/community/component/my_post_feed.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
-import 'package:mojacknong_android/common/bouncing.dart';
 import 'package:mojacknong_android/view/community/component/community_comment_count.dart';
 import 'package:mojacknong_android/view/community/component/community_content.dart';
 import 'package:mojacknong_android/view/community/component/community_picture.dart';
 import 'package:mojacknong_android/view/community/component/community_post_time.dart';
 import 'package:mojacknong_android/view/community/component/post_category.dart';
+import 'package:mojacknong_android/view/community/detail/detail_post_screen.dart';
 
 class MyPostFeed extends StatelessWidget {
   final String postTime;
@@ -26,8 +26,25 @@ class MyPostFeed extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Bouncing(
-      onPress: () {},
+    return GestureDetector(
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) {
+              return DetailPostScreen(
+                profileImage: "assets/image/image_example_profile.png",
+                nickname: "어쩌구",
+                postTime: postTime,
+                postCategory: postCategory,
+                title: title,
+                content: content,
+                image: image,
+              );
+            },
+          ),
+        );
+      },
       child: Padding(
         padding: const EdgeInsets.all(8.0),
         child: Column(

--- a/lib/view/community/my_post/my_post_screen.dart
+++ b/lib/view/community/my_post/my_post_screen.dart
@@ -7,7 +7,7 @@ class MyPostScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: PrimaryAppBar(
-        title: "나의 게시글",
+        title: "내 글",
       ),
       body: SingleChildScrollView(
         child: Column(

--- a/lib/view/community/post/post_screen.dart
+++ b/lib/view/community/post/post_screen.dart
@@ -6,7 +6,7 @@ import 'package:get/get.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
 import 'package:mojacknong_android/common/primary_app_bar.dart';
-import 'package:mojacknong_android/view/community/component/community_category.dart';
+import 'package:mojacknong_android/view/community/component/category_list.dart';
 import 'package:mojacknong_android/view_model/controllers/community_post_controller.dart';
 
 class PostScreen extends StatefulWidget {
@@ -64,7 +64,7 @@ class _PostScreenState extends State<PostScreen> {
         children: [
           Center(
             child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.start,
                 children: [
@@ -78,42 +78,10 @@ class _PostScreenState extends State<PostScreen> {
                           fontFamily: "Pretendard",
                         ),
                       ),
-                      CommunityCategory(
-                        postController: postController,
-                        category: "도와주세요",
-                        isSelected: isSelected[0],
-                        onSelected: () {
-                          setState(() {
-                            // 선택된 카테고리의 isSelected 값을 변경
-                            isSelected = [true, false, false];
-                            postController.selectCategory1();
-                          });
-                        },
+                      SizedBox(
+                        width: 8,
                       ),
-                      CommunityCategory(
-                        postController: postController,
-                        category: "자랑할래요",
-                        isSelected: isSelected[1],
-                        onSelected: () {
-                          setState(() {
-                            // 선택된 카테고리의 isSelected 값을 변경
-                            isSelected = [false, true, false];
-                            postController.selectCategory2();
-                          });
-                        },
-                      ),
-                      CommunityCategory(
-                        postController: postController,
-                        category: "정보나눠요",
-                        isSelected: isSelected[2],
-                        onSelected: () {
-                          setState(() {
-                            // 선택된 카테고리의 isSelected 값을 변경
-                            isSelected = [false, false, true];
-                            postController.selectCategory3();
-                          });
-                        },
-                      ),
+                      CategoryList(),
                     ],
                   ),
                   TextFormField(

--- a/lib/view/community/post/post_screen.dart
+++ b/lib/view/community/post/post_screen.dart
@@ -104,7 +104,7 @@ class _PostScreenState extends State<PostScreen> {
                       ),
                       CommunityCategory(
                         postController: postController,
-                        category: "정보나눔",
+                        category: "정보나눠요",
                         isSelected: isSelected[2],
                         onSelected: () {
                           setState(() {

--- a/lib/view/login/login_screen.dart
+++ b/lib/view/login/login_screen.dart
@@ -8,6 +8,7 @@ import 'package:kakao_flutter_sdk/kakao_flutter_sdk_talk.dart';
 import 'package:mojacknong_android/common/bouncing.dart';
 import 'package:mojacknong_android/common/custom_app_bar.dart';
 import 'package:mojacknong_android/common/farmus_theme_data.dart';
+import 'package:mojacknong_android/model/farmus_user.dart';
 import 'package:mojacknong_android/repository/login_repository.dart';
 import 'package:mojacknong_android/view/login/app_interceptor.dart';
 import 'package:mojacknong_android/view/main/main_screen.dart';
@@ -36,6 +37,8 @@ class LoginScreen extends StatefulWidget {
 }
 
 class _LoginScreen extends State<LoginScreen> {
+  late FarmusUser user;
+
   @override
   Widget build(BuildContext context) {
     authDio.interceptors.add(AppInterceptor(authDio));
@@ -137,14 +140,17 @@ class _LoginScreen extends State<LoginScreen> {
   fetchKaKaoData(token) {
     LoginRepository.kakaoLoginApi(token).then(
       (value) {
-        if (value == "earlyTrue") {
-          print(value);
+        setState(() {
+          user = value;
+        });
+        print(value.early);
+        print(value.nickName);
+
+        if (value.early == true) {
           Navigator.of(context).push(
             MaterialPageRoute(builder: (context) => OnboardingScreen()),
           );
-        } else if (value == "earlyFalse") {
-          print(value);
-
+        } else {
           Navigator.of(context).push(
             MaterialPageRoute(builder: (context) => MainScreen()),
           );

--- a/lib/view/login/login_screen.dart
+++ b/lib/view/login/login_screen.dart
@@ -159,17 +159,29 @@ class _LoginScreen extends State<LoginScreen> {
     );
   }
 
-  googleLogin() {
-    LoginRepository.googleLoginApi().then(
+  googleLogin() async {
+    print("구글 로그인 버튼 클릭");
+
+    final GoogleSignInAccount? googleSignInAccount =
+        await googleSignIn.signIn();
+
+    final GoogleSignInAuthentication googleSignInAuthentication =
+        await googleSignInAccount!.authentication;
+
+    print("구글 액세스 토큰 ${googleSignInAuthentication.accessToken}");
+    LoginRepository.googleLoginApi(googleSignInAuthentication.accessToken).then(
       (value) {
-        if (value == "earlyTrue") {
-          print(value);
+        setState(() {
+          user = value;
+        });
+        print("초기 로그인 ${value.early}");
+        print(value.nickName);
+
+        if (value.early == true) {
           Navigator.of(context).push(
             MaterialPageRoute(builder: (context) => OnboardingScreen()),
           );
-        } else if (value == "earlyFalse") {
-          print(value);
-
+        } else {
           Navigator.of(context).push(
             MaterialPageRoute(builder: (context) => MainScreen()),
           );

--- a/lib/view/onboarding/component/onboarding_first.dart
+++ b/lib/view/onboarding/component/onboarding_first.dart
@@ -34,9 +34,14 @@ class _OnboardingFirstState extends State<OnboardingFirst> {
 
   Future<void> _setInitialImage() async {
     String? profileImage = await getFirstProfileImage();
-    if (profileImage != null) {
+    print(profileImage);
+    if (profileImage != "") {
       setState(() {
         _profileImage = profileImage;
+      });
+    } else {
+      setState(() {
+        _profileImage = null;
       });
     }
   }

--- a/lib/view/onboarding/component/onboarding_first.dart
+++ b/lib/view/onboarding/component/onboarding_first.dart
@@ -56,6 +56,8 @@ class _OnboardingFirstState extends State<OnboardingFirst> {
       });
       _controller.setImageFile(File(pickedFile.path));
     } else {
+      print("냥냥");
+
       setState(() {
         _profileImage = null;
       });

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -354,10 +354,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: bfc7cc3c75fe1282e8ce2e056d8fd1533f1a6848b65c379b4a5e7a9b623d3371
+      sha256: d39e7f95621fc84376bc0f7d504f05c3a41488c562f4a8ad410569127507402c
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.8"
+    version: "2.0.9"
   flutter_test:
     dependency: "direct dev"
     description: flutter


### PR DESCRIPTION
### 🥕 Issue number and Link
이슈 번호 : #27 


### 🍠 Summary
커뮤니티 API 통신을 위한 기본적인 틀을 구축하였고,
전체 게시글 조회는 연동 확인한 상태입니다.

게시글 작성 페이지의 카테고리를 한 개만 선택할 수 있도록 구현하였고
UI 라이팅 수정 반영하여 텍스트 변경했습니다.

로그인 API가 데이터 모델이 없는 상태였는데,
FarmusUser 데이터 모델을 생성하여 해당 데이터 모델로 통신하도록 리팩토링했습니다.


### 🌽 PR Type
- [x] Feature
- [ ] Bugfix
- [ ] Code Style Update
- [x] Refactoring
- [ ] Documentation content change
- [ ] Other


### 🫛 Other Information
